### PR TITLE
Fixes for `blend` example

### DIFF
--- a/examples/blend/sketch.js
+++ b/examples/blend/sketch.js
@@ -9,46 +9,51 @@ let layer1, layer2,
   blend,
   blendingModeIndex = 0;
 
-function setup() {
-    createCanvas(600, 600, WEBGL); // Enable WEBGL mode for shaders
-    
-    blend = createFilterShader(fip.blend); // Load the blend shader
-    
+  function preload(){
     ireland = loadImage("ireland.jpg");
     bird = loadImage("bird.jpg");
-    
-    // Create 2 framebuffers so we can control which textures are sent to the shaders
-    layer1 = createFramebuffer();
-    layer2 = createFramebuffer();
-    
-    console.log("Press any key to cycle through blending modes.");
-}
+  }
   
-function draw() {
-    background(0);
-    imageMode(CENTER);
+  function setup() {
+      createCanvas(600, 600, WEBGL); // Enable WEBGL mode for shaders
   
-    layer1.begin();
-    image(ireland, 0, 0, width, height);
-    layer1.end();
-
-    layer2.begin();
-    image(bird, 0, 0, width, height);
-    layer2.end();
-    
-    // Apply the blend shader
-    filter(blend);
-    
-    // Send our two textures to the shader
-    blend.setUniform('texture1', layer1.color);
-    blend.setUniform('texture2', layer2.color);
-    blend.setUniform("uTextureSize", [width, height]);
-    blend.setUniform('mixFactor', 0.5);
-    blend.setUniform('blendingMode', blendingModeIndex);
-}
+      blend = createFilterShader(fip.blend); // Load the blend shader
   
-function keyPressed() {
-    // Cycle through blending modes when a key is pressed
-    blendingModeIndex = (blendingModeIndex + 1) % 14; // 14 types of blending
-    console.log("Blending Mode: " + blendingModeIndex);
-}
+      // Create 2 framebuffers so we can control which textures are sent to the shaders
+      layer1 = createFramebuffer();
+      layer2 = createFramebuffer();
+  
+      console.log("Press any key to cycle through blending modes.");
+  }
+  
+  function draw() {
+      background(0);
+      imageMode(CENTER);
+    
+      layer1.begin();
+      image(ireland, 0, 0, width, height);
+      layer1.end();
+  
+      layer2.begin();
+      image(bird, 0, 0, width, height);
+      layer2.end();
+    
+      // Send our two textures to the shader
+      blend.setUniform('texture1', layer1.color);
+      blend.setUniform('texture2', layer2.color);
+      blend.setUniform("uTextureSize", [width, height]);
+      blend.setUniform('mixFactor', 0.5);
+      blend.setUniform('blendingMode', blendingModeIndex);
+    
+      // Apply the blend shader
+      filter(blend);
+    
+      noLoop();
+  }
+  
+  function keyPressed() {
+      // Cycle through blending modes when a key is pressed
+      blendingModeIndex = (blendingModeIndex + 1) % 14; // 14 types of blending
+      console.log("Blending Mode: " + blendingModeIndex);
+      loop();
+  }


### PR DESCRIPTION
Fixes the `blend` example so the filter works already on frame 1.

This includes loading the images in `preload()` and setting the uniforms before calling `filter()`.

Also added `noLoop()` since the example only needs to render one frame at a time.

Note: it may be a good idea to make similar modifications to the other examples.

See #2 